### PR TITLE
Fix deployment environment setting for Azure Static Web Apps to use d…

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -123,8 +123,8 @@ jobs:
           api_location: ""
           output_location: ""
           skip_app_build: true
-          # Set the deployment environment (production or staging)
-          deployment_environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+          # Set the deployment environment - use empty string for main branch to use default production environment
+          deployment_environment: ${{ github.ref == 'refs/heads/main' && '' || 'staging' }}
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'


### PR DESCRIPTION

This pull request includes a small change to the `.github/workflows/azure-static-web-apps.yml` file. The change updates the logic for setting the deployment environment, ensuring that the main branch uses the default production environment by setting the `deployment_environment` to an empty string.

* [`.github/workflows/azure-static-web-apps.yml`](diffhunk://#diff-74445b0ef0e42e1aa2b56af11871ef76e88ac2aee50301be5f937b180a3b2f7fL126-R127): Updated the `deployment_environment` logic to use an empty string for the main branch, ensuring it defaults to the production environment.